### PR TITLE
Fix parsing of functions with return types

### DIFF
--- a/server/src/Skript/Section/SkriptFunctionSection.ts
+++ b/server/src/Skript/Section/SkriptFunctionSection.ts
@@ -17,7 +17,7 @@ export class SkriptFunction extends SkriptSection {
 	//context.currentString should be 'function example(a: string, b: number) :: string' for example
 	constructor(parent: SkriptSection, context: SkriptContext) {
 		super(parent, context);
-		const regex = /^function ([a-zA-Z0-9_]{1,})\((.*)\)(?:| ?(?:::|returns ) (.*?))$/; // /function ([a-zA-Z0-9]{1,})\(.*)\) :: (.*)/;
+		const regex = /^function ([a-zA-Z0-9_]{1,})\((.*)\)(?:(?: *:: *| {1,}returns {1,})(.*?))$/; // /function ([a-zA-Z0-9]{1,})\(.*)\) :: (.*)/;
 		//(,|and|)){1,}\)
 		const result = regex.exec(context.currentString);
 		if (result == null) {


### PR DESCRIPTION
Fixes https://github.com/JohnHeikens/IntelliSkript/issues/121

This pull request introduces a new regex for parsing the function section
Basically it just allows:
* an arbitrary number of spaces before and after the delimeter `::`
* requires at least one space around `returns`

After some testing, I came up with these test strings:
```python
# valid functions recognized by SkriptLang
function f1()::string:
function f2():: string:
function f3() ::string:
function f4() :: string:
function f5()       ::  string:
function f6() returns string:
function f7() returns  string:
function f8()                    returns                     string:
function f9() returns some custom type:
function f10()::string
function f11() returns string

# invalid functions
function f01(): : string:
function f03(): :: string
function f04()returns string

# can be valid in some cases (relying on the type parser)
function f05():::string
function f06() :: :: :: string
function f07():: :the other type:
```

Then tested both new and original regex against these strings (screenshots from regex101.com)

Original            |  New
:-------------------------:|:-------------------------:
<img width="966" height="848" alt="image" src="https://github.com/user-attachments/assets/8eac6041-35c0-4e92-be7e-608a8dac5a6d" />  |  <img width="968" height="850" alt="image" src="https://github.com/user-attachments/assets/522ec545-aee5-449e-8672-09b1856c9e5b" />

Functions marked as `valid in some cases` are technically invalid in vanilla Skript but can become valid if an addon actually provides a type like `:string`
The Skript itself says
>  Line 22: (temp.sk)
> Cannot recognise the type ':string'
> Line: function f08():::string:

My goal was to preserve the existing logic of matching groups so I chose to let those cases pass and be validated by the type parser if needed
 